### PR TITLE
(For Aaron) Remove persisted event data when we are removing a queue

### DIFF
--- a/Sift/SFQueue.h
+++ b/Sift/SFQueue.h
@@ -20,6 +20,9 @@
  */
 - (void)archive;
 
+/** Remove persisted events from disk. */
+- (void)removeData;
+
 /** Append an event to the queue. */
 - (void)append:(SFEvent *)event;
 

--- a/Sift/SFQueue.m
+++ b/Sift/SFQueue.m
@@ -93,4 +93,13 @@ static NSString * const SF_LAST_EVENT_TIMESTAMP = @"lastEventTimestamp";
     }
 }
 
+- (void)removeData {
+    @synchronized(self) {
+        NSError *error;
+        if (![[NSFileManager defaultManager] removeItemAtPath:_archivePath error:&error]) {
+            SF_DEBUG(@"Could not remove queue archive \"%@\" due to %@", _archivePath, [error localizedDescription]);
+        }
+    }
+}
+
 @end

--- a/Sift/Sift.m
+++ b/Sift/Sift.m
@@ -88,10 +88,12 @@ static const SFQueueConfig SFDefaultEventQueueConfig = {
 
 - (BOOL)removeEventQueue:(NSString *)identifier {
     @synchronized(_eventQueues) {
-        if (![_eventQueues objectForKey:identifier]) {
+        SFQueue *queue = [_eventQueues objectForKey:identifier];
+        if (!queue) {
             SF_DEBUG(@"Could not find event queue to be removed for identifier \"%@\"", identifier);
             return NO;
         }
+        [queue removeData];
         [_eventQueues removeObjectForKey:identifier];
         return YES;
     }

--- a/SiftTests/SFQueueTests.m
+++ b/SiftTests/SFQueueTests.m
@@ -67,6 +67,12 @@
     XCTAssertEqualObjects([(SFEvent *)[events objectAtIndex:0] path], @"path-0");
     XCTAssertEqualObjects([(SFEvent *)[events objectAtIndex:1] path], @"path-1");
     XCTAssertEqualObjects([(SFEvent *)[events objectAtIndex:2] path], @"path-2");
+
+    // Remove persisted data...
+    [queue removeData];
+    anotherQueue = [self makeQueue:config];
+    events = [anotherQueue transfer];
+    XCTAssertEqual(events.count, 0);
 }
 
 - (SFQueue *)makeQueue:(SFQueueConfig)config {


### PR DESCRIPTION
@abeppu 

This is a minor change (and depend on how our API will be, maybe we will not merge this).

Basically, currently after a user removes a queue from `Sift`, because the events still persisted on the disk, if he adds a queue with the same name, the new queue will load back the old event data, which might be surprising to him.

This change removes the persisted data so this won't happen.
