### PR TITLE
(For Aaron) Add timeout for accepting the same event again

### DIFF
--- a/Sift/SFDevicePropertiesReporter.m
+++ b/Sift/SFDevicePropertiesReporter.m
@@ -29,6 +29,7 @@
  */
 static const SFQueueConfig SFDevicePropertiesReporterQueueConfig = {
     .appendEventOnlyWhenDifferent = YES,  // Only track difference.
+    .acceptSameEventAfter = 600,  // 10 minutes
     .uploadWhenMoreThan = 8,  // More than 8 events
     .uploadWhenOlderThan = 60,  // 1 minute
 };

--- a/Sift/SFQueue.m
+++ b/Sift/SFQueue.m
@@ -47,14 +47,19 @@
         if (!event) {
             return;  // Don't append nil.
         }
-        if (_config.appendEventOnlyWhenDifferent && _lastEvent && [_lastEvent isEssentiallyEqualTo:event]) {
+
+        SFTimestamp now = SFCurrentTime();
+        if (_config.appendEventOnlyWhenDifferent &&
+            _lastEvent &&
+            [_lastEvent isEssentiallyEqualTo:event] &&
+            (!_config.acceptSameEventAfter || now - _lastEventTimestamp < _config.acceptSameEventAfter * 1000)) {
             SF_DEBUG(@"Drop the same event");
             return;  // Drop the same event as configured.
         }
 
         [_queue addObject:event];
         _lastEvent = event;
-        _lastEventTimestamp = SFCurrentTime();
+        _lastEventTimestamp = now;
 
         // Unfortunately iOS does not guarantee to always call you
         // before terminating your app and thus we have to persist data

--- a/Sift/SFQueueConfig.h
+++ b/Sift/SFQueueConfig.h
@@ -20,6 +20,14 @@ typedef struct {
     BOOL appendEventOnlyWhenDifferent;
 
     /**
+     * When `appendEventOnlyWhenDifferent` is `YES`, the queue will
+     * accept the same event again after this amount of time.
+     *
+     * Setting this to 0 is treated as infinite.
+     */
+    NSTimeInterval acceptSameEventAfter;
+
+    /**
      * The following criteria are combined by "or", meaning if one of
      * them is met, the events of the queue will be uploaded.
      */


### PR DESCRIPTION
On things that change rarely but we want to query it often, we have an
optimization that instructs a queue to only accept different events.
Sometimes we want to enqueue and upload the same event, just to make
sure that the device is still "alive".  This change add a timeout for
that.

@abeppu cc @fredsadaghiani 
