### PR TITLE
(For Aaron) Drop events if they are rejected too many times

### DIFF
--- a/Sift.xcodeproj/project.pbxproj
+++ b/Sift.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		7168EE351C864A4100A88245 /* SFDevicePropertiesReporter.m in Sources */ = {isa = PBXBuildFile; fileRef = 7168EE331C864A4100A88245 /* SFDevicePropertiesReporter.m */; };
 		7168EE381C8665A200A88245 /* SFAppEventsReporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 7168EE361C8665A200A88245 /* SFAppEventsReporter.h */; };
 		7168EE391C8665A200A88245 /* SFAppEventsReporter.m in Sources */ = {isa = PBXBuildFile; fileRef = 7168EE371C8665A200A88245 /* SFAppEventsReporter.m */; };
+		7168EE411C88C91900A88245 /* SFStubHttpProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = 7168EE3F1C88C91900A88245 /* SFStubHttpProtocol.m */; };
+		7168EE421C88C91900A88245 /* SFUploaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7168EE401C88C91900A88245 /* SFUploaderTests.m */; };
 		716BEB871C7D304D009C3706 /* SFDebug.h in Headers */ = {isa = PBXBuildFile; fileRef = 716BEB861C7D304D009C3706 /* SFDebug.h */; };
 		716BEB8A1C7D336B009C3706 /* SFEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 716BEB881C7D336B009C3706 /* SFEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		716BEB8B1C7D336B009C3706 /* SFQueueConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 716BEB891C7D336B009C3706 /* SFQueueConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -60,6 +62,9 @@
 		7168EE331C864A4100A88245 /* SFDevicePropertiesReporter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFDevicePropertiesReporter.m; sourceTree = "<group>"; };
 		7168EE361C8665A200A88245 /* SFAppEventsReporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFAppEventsReporter.h; sourceTree = "<group>"; };
 		7168EE371C8665A200A88245 /* SFAppEventsReporter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFAppEventsReporter.m; sourceTree = "<group>"; };
+		7168EE3E1C88C91900A88245 /* SFStubHttpProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFStubHttpProtocol.h; sourceTree = "<group>"; };
+		7168EE3F1C88C91900A88245 /* SFStubHttpProtocol.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFStubHttpProtocol.m; sourceTree = "<group>"; };
+		7168EE401C88C91900A88245 /* SFUploaderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFUploaderTests.m; sourceTree = "<group>"; };
 		716BEB861C7D304D009C3706 /* SFDebug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFDebug.h; sourceTree = "<group>"; };
 		716BEB881C7D336B009C3706 /* SFEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFEvent.h; sourceTree = "<group>"; };
 		716BEB891C7D336B009C3706 /* SFQueueConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFQueueConfig.h; sourceTree = "<group>"; };
@@ -138,6 +143,9 @@
 				7168EE121C7B977500A88245 /* Info.plist */,
 				7168EE1B1C7E61E900A88245 /* SFEventTests.m */,
 				7168EE231C7F99AF00A88245 /* SFQueueTests.m */,
+				7168EE3E1C88C91900A88245 /* SFStubHttpProtocol.h */,
+				7168EE3F1C88C91900A88245 /* SFStubHttpProtocol.m */,
+				7168EE401C88C91900A88245 /* SFUploaderTests.m */,
 				7168EE101C7B977500A88245 /* SiftTests.m */,
 			);
 			path = SiftTests;
@@ -274,9 +282,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7168EE411C88C91900A88245 /* SFStubHttpProtocol.m in Sources */,
 				7168EE111C7B977500A88245 /* SiftTests.m in Sources */,
 				7168EE1C1C7E61E900A88245 /* SFEventTests.m in Sources */,
 				7168EE241C7F99AF00A88245 /* SFQueueTests.m in Sources */,
+				7168EE421C88C91900A88245 /* SFUploaderTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sift/SFUploader.h
+++ b/Sift/SFUploader.h
@@ -8,6 +8,9 @@
 
 - (instancetype)initWithArchivePath:(NSString *)archivePath sift:(Sift *)sift;
 
+/** For testing. */
+- (instancetype)initWithArchivePath:(NSString *)archivePath sift:(Sift *)sift config:(NSURLSessionConfiguration *)config backoffBase:(int64_t)backoffBase;
+
 /** Persist uploader state to disk. */
 - (void)archive;
 

--- a/SiftTests/SFStubHttpProtocol.h
+++ b/SiftTests/SFStubHttpProtocol.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2016 Sift Science. All rights reserved.
+
+@import Foundation;
+
+NSURLSessionConfiguration *SFMakeStubConfig(void);
+
+typedef void (^CompletionHandlerType)(void);
+
+@interface SFHttpStub : NSObject
+
++ (SFHttpStub *)sharedInstance;
+
+@property NSMutableArray<NSNumber *> *stubbedStatusCodes;
+
+@property NSMutableArray<NSURLRequest *> *capturedRequests;
+
+@property (nonatomic, copy) CompletionHandlerType completionHandler;
+
+@end

--- a/SiftTests/SFStubHttpProtocol.m
+++ b/SiftTests/SFStubHttpProtocol.m
@@ -1,0 +1,76 @@
+// Copyright (c) 2016 Sift Science. All rights reserved.
+
+@import Foundation;
+
+#import "SFStubHttpProtocol.h"
+
+@implementation SFHttpStub
+
++ (SFHttpStub *)sharedInstance {
+    static SFHttpStub *stub;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        stub = [SFHttpStub new];
+    });
+    return stub;
+}
+
+- (instancetype) init {
+    self = [super init];
+    if (self) {
+        _stubbedStatusCodes = [NSMutableArray new];
+        _capturedRequests = [NSMutableArray new];
+        _completionHandler = nil;
+    }
+    return self;
+}
+
+@end
+
+@interface SFStubHttpProtocol : NSURLProtocol
+@end
+
+NSURLSessionConfiguration *SFMakeStubConfig(void) {
+    NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
+    config.protocolClasses = [config.protocolClasses arrayByAddingObject:[SFStubHttpProtocol class]];
+    return config;
+}
+
+@implementation SFStubHttpProtocol
+
++ (BOOL)canInitWithRequest:(NSURLRequest *)request {
+    return [[[request URL] scheme] isEqualToString:@"mock+https"];
+}
+
++ (NSURLRequest *)canonicalRequestForRequest:(NSURLRequest *)request {
+    return request;
+}
+
++ (BOOL)requestIsCacheEquivalent:(NSURLRequest *)a toRequest:(NSURLRequest *)b {
+    return [[a URL] isEqual:[b URL]];
+}
+
+- (void)startLoading {
+    SFHttpStub *stub = [SFHttpStub sharedInstance];
+    [stub.capturedRequests addObject:self.request];
+
+    int statusCode = 500;
+    if (stub.stubbedStatusCodes.count) {
+        statusCode = [stub.stubbedStatusCodes objectAtIndex:0].intValue;
+        [stub.stubbedStatusCodes removeObjectAtIndex:0];
+    }
+
+    NSURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.request.URL statusCode:statusCode HTTPVersion:@"HTTP/1.1" headerFields:nil];
+    [self.client URLProtocol:self didReceiveResponse:response cacheStoragePolicy:NSURLCacheStorageAllowedInMemoryOnly];
+    [self.client URLProtocolDidFinishLoading:self];
+
+    if (!stub.stubbedStatusCodes.count) {
+        stub.completionHandler();
+    }
+}
+
+- (void)stopLoading {
+    // Nothing yet...
+}
+
+@end

--- a/SiftTests/SFUploaderTests.m
+++ b/SiftTests/SFUploaderTests.m
@@ -1,0 +1,110 @@
+// Copyright (c) 2016 Sift Science. All rights reserved.
+
+@import XCTest;
+
+#import "SFEvent.h"
+#import "Sift.h"
+#import "Sift+Private.h"
+
+#import "SFUploader.h"
+
+#import "SFStubHttpProtocol.h"
+
+@interface SFEventFileUploaderTests : XCTestCase
+
+@end
+
+@implementation SFEventFileUploaderTests {
+    Sift *_sift;
+    SFUploader *_uploader;
+}
+
+- (void)setUp {
+    [super setUp];
+
+    _sift = [[Sift alloc] init];  // Don't call initWithRootDirPath.
+    _sift.accountId = @"account_id";
+    _sift.beaconKey = @"beacon_key";
+    _sift.userId = @"user_id";
+    _sift.serverUrlFormat = @"mock+https://127.0.0.1/v3/accounts/%@/mobile_events";
+
+    // Disable exponential backoff with baseoffBase = 0.
+    _uploader = [[SFUploader alloc] initWithArchivePath:nil sift:_sift config:SFMakeStubConfig() backoffBase:0];
+
+    SFHttpStub *stub = [SFHttpStub sharedInstance];
+    [stub.stubbedStatusCodes removeAllObjects];
+    [stub.capturedRequests removeAllObjects];
+}
+
+- (void)tearDown {
+    [super tearDown];
+}
+
+- (void)testUpload {
+    SFHttpStub *stub = [SFHttpStub sharedInstance];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for upload tasks completion"];
+    stub.completionHandler = ^{
+        [expectation fulfill];
+    };
+
+    [stub.stubbedStatusCodes addObject:@200];
+
+    NSArray *events = @[[SFEvent eventWithType:nil path:@"path" fields:nil]];
+    [_uploader upload:events];
+
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+
+    XCTAssertEqual(stub.stubbedStatusCodes.count, 0);
+    XCTAssertEqual(stub.capturedRequests.count, 1);
+}
+
+- (void)testUploadRejected {
+    SFHttpStub *stub = [SFHttpStub sharedInstance];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for upload tasks completion"];
+    stub.completionHandler = ^{
+        [expectation fulfill];
+    };
+
+    // SFUploader takes three rejects.
+    [stub.stubbedStatusCodes addObject:@400];
+    [stub.stubbedStatusCodes addObject:@400];
+    [stub.stubbedStatusCodes addObject:@400];
+
+    NSArray *events = @[[SFEvent eventWithType:nil path:@"path" fields:nil]];
+    [_uploader upload:events];
+
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+
+    XCTAssertEqual(stub.stubbedStatusCodes.count, 0);
+    XCTAssertEqual(stub.capturedRequests.count, 3);
+}
+
+- (void)testUploadHttpError {
+    SFHttpStub *stub = [SFHttpStub sharedInstance];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for upload tasks completion"];
+    stub.completionHandler = ^{
+        [expectation fulfill];
+    };
+
+    // Non-400 are not considered rejects.
+    [stub.stubbedStatusCodes addObject:@404];
+    [stub.stubbedStatusCodes addObject:@500];
+    [stub.stubbedStatusCodes addObject:@404];
+    [stub.stubbedStatusCodes addObject:@500];
+    [stub.stubbedStatusCodes addObject:@404];
+    [stub.stubbedStatusCodes addObject:@500];
+    [stub.stubbedStatusCodes addObject:@200];
+
+    NSArray *events = @[[SFEvent eventWithType:nil path:@"path" fields:nil]];
+    [_uploader upload:events];
+
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+
+    XCTAssertEqual(stub.stubbedStatusCodes.count, 0);
+    XCTAssertEqual(stub.capturedRequests.count, 7);
+}
+
+@end


### PR DESCRIPTION
@abeppu cc @fredsadaghiani 

In case events get constantly rejected by our backend because they are corrupted/version-too-old/whatever-reason, we should drop those events in order to make progress.

Note that events get rejected (HTTP status code != 200) and network error are different.
