### PR TITLE
(For Aaron) Let users choose the default queue identifier

### DIFF
--- a/Sift/Sift.h
+++ b/Sift/Sift.h
@@ -70,6 +70,13 @@
  */
 
 /**
+ * The default queue identifier.
+ *
+ * This is used when you call `appendEvent` without an identifier.
+ */
+@property NSString *defaultQueueIdentifier;
+
+/**
  * Your account ID.  Default to nil.
  *
  * NOTE: This is persisted to device's storage.

--- a/Sift/Sift.m
+++ b/Sift/Sift.m
@@ -85,6 +85,7 @@ static const SFQueueConfig SFDefaultEventQueueConfig = {
             self = nil;
             return nil;
         }
+        _defaultQueueIdentifier = SFDefaultEventQueueIdentifier;
 
         NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
         [notificationCenter addObserver:self selector:@selector(applicationDidEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
@@ -144,7 +145,7 @@ static const SFQueueConfig SFDefaultEventQueueConfig = {
 }
 
 - (BOOL)appendEvent:(SFEvent *)event withLocation:(BOOL)withLocation {
-    return [self appendEvent:event withLocation:withLocation toQueue:SFDefaultEventQueueIdentifier];
+    return [self appendEvent:event withLocation:withLocation toQueue:_defaultQueueIdentifier];
 }
 
 - (BOOL)appendEvent:(SFEvent *)event withLocation:(BOOL)withLocation toQueue:(NSString *)identifier {


### PR DESCRIPTION
Currently we provide a default queue to SDK users, but they might want
to tweak the configurations of the default queue.  However, it also
might be a good idea to keep the queue configurations immutable once the
queue is created.

So we could probably solve it this way: Let users create a new queue
with the configurations of their choice, and tell the SDK to treat that
queue as the default one (by setting the `defaultQueueIdentifier`
property of the `Sift` object).

@abeppu 
