### PR TITLE
(For Aaron) Fix fork safety issue when poking device properties

### DIFF
--- a/Sift/SFDevicePropertiesReporter.m
+++ b/Sift/SFDevicePropertiesReporter.m
@@ -340,18 +340,14 @@ static NSString *SFSysctlReadInt64(const char *name) {
 
     // 2. Sytem-call detection.
 
-    // This is not fork-safe; disable it until we figure out how to do
-    // it safely.
-#if 0
     pid_t pid = fork();
     if (!pid) {
-        exit(0);
+        _exit(0);  // _exit() is fork safe but exit() is not.
     } else if (pid > 0) {
         SF_DEBUG(@"fork() does not return error");
         [report setObject:@"fork" forKey:@"suspicious_call.0"];
         waitpid(pid, NULL, 0);
     }
-#endif
 
     // system(NULL) will trigger SIGABRT?
 


### PR DESCRIPTION
@abeppu 

Unfortunately I was not able to really test this issue. On non-jailbroken iOS devices, `fork()` would return -1 and so we would not see any "you must exec" kind of warnings. And I don't have a jailbroken device for testing. On simulator, `fork()` would succeed but the runtime will not warn you about you didn't call `exec()`. Any idea?
