### PR TITLE
(For David) Adds unsetUserId to Sift and uses nil check instead of length

### DIFF
--- a/Sift/Sift.h
+++ b/Sift/Sift.h
@@ -64,6 +64,11 @@
 - (BOOL)appendEvent:(SFEvent *)event;
 
 /**
+ * Unset the user id attached to the Sift object.
+ */
+- (void)unsetUserId;
+
+/**
  * @name Configurations.
  *
  * You should configure `accountId`, `beaconKey`, and `userId`.

--- a/Sift/Sift.m
+++ b/Sift/Sift.m
@@ -151,7 +151,7 @@ static const SFQueueConfig SFDefaultEventQueueConfig = {
             return NO;
         }
         // Record user ID when receiving the event, not when uploading the event.
-        if (!event.userId.length && _userId.length) {
+        if (!event.userId && _userId) {
             SF_DEBUG(@"The event's userId is empty; use Sift object's userId: \"%@\"", _userId);
             event.userId = _userId;
         }
@@ -219,6 +219,11 @@ static const SFQueueConfig SFDefaultEventQueueConfig = {
 
 - (void)setUserId:(NSString *)userId {
     _userId = userId;
+    [self archiveKeys];
+}
+
+- (void)unsetUserId {
+    _userId = nil;
     [self archiveKeys];
 }
 

--- a/SiftTests/SiftTests.m
+++ b/SiftTests/SiftTests.m
@@ -29,10 +29,10 @@
 }
 
 - (void)testAppendEvent {
-    _sift.userId = nil;
+    [_sift unsetUserId];
     XCTAssertTrue([_sift appendEvent:[SFEvent eventWithType:nil path:nil fields:nil]]);
 
-    _sift.userId = @"1234";
+    [_sift setUserId:@"1234"];
     XCTAssertTrue([_sift appendEvent:[SFEvent eventWithType:nil path:nil fields:nil]]);
 }
 


### PR DESCRIPTION
@ehrmann As discussed in the lobby. The scenario described I believe is only possible in a framework that does not dynamically compile Objective-c, since sending a message to nil is normally okay. It would have been the case that the built artifact allowed for calling setUserId without typechecked arguments. We can think about how to deal with this later, but for now it's just a fringe incorrect integration.

Anyway, I've changed the check to nil instead of length, and added a hook into unsetting the userId as well.