### PR TITLE
(For David) Remove fork check

### DIFF
--- a/Sift/SFIosDeviceProperties.m
+++ b/Sift/SFIosDeviceProperties.m
@@ -408,22 +408,7 @@ SFHtDictionary *SFCollectIosDeviceProperties() {
 
     [iosDeviceProperties setEntry:@"evidence_dylds_present" value:dyldsPresent];
 
-    // 3. System call detection.
-
-    SF_GENERICS(NSMutableArray, NSString *) *syscallsSucceeded = [NSMutableArray new];
-
-    pid_t pid = fork();
-    if (!pid) {
-        _exit(0); // _exit() is fork safe but exit() is not.
-    } else if (pid > 0) {
-        SF_DEBUG(@"fork() does not return error");
-        [syscallsSucceeded addObject:@"fork"];
-        waitpid(pid, NULL, 0);
-    }
-
-    [iosDeviceProperties setEntry:@"evidence_syscalls_succeeded" value:syscallsSucceeded];
-
-    // 4. Cydia URL scheme detection.
+    // 3. Cydia URL scheme detection.
 
     // Because when we poke iOS about this, it reports an error, and
     // that sometimes confuses SDK users, we will only poke once per


### PR DESCRIPTION
Customers have reported that this check can sometimes lead to deadlock. I've concluded that the scenario that the `fork` call checks for is already covered by our three other jailbroken detection techniques, so we should remove this.