### PR TITLE
remove all warnings during build of iOS SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
-## [2.0.0] - 2019-02-25
+## [2.0.1] - 2020-03-04
+- Remove all warnings which gets generated during build
+
+## [2.0.0] - 2020-02-25
 - Rename classes to remove SF reserve keyword from their names
 
 ## [1.0.1] - 2018-07-17

--- a/HelloSift/Cartfile
+++ b/HelloSift/Cartfile
@@ -1,1 +1,1 @@
-github "SiftScience/sift-ios" ~> 2.0.0
+github "SiftScience/sift-ios" ~> 2.0.1

--- a/HelloSift/Cartfile.resolved
+++ b/HelloSift/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "SiftScience/sift-ios" "v0.9.7"
+github "SiftScience/sift-ios" "v2.0.1"

--- a/Sift.podspec
+++ b/Sift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = 'Sift'
-  spec.version = '2.0.0'
+  spec.version = '2.0.1'
   spec.authors = 'Sift Science'
   spec.license = {
     :type => 'MIT',

--- a/Sift/Sift.m
+++ b/Sift/Sift.m
@@ -55,7 +55,7 @@ static const SiftQueueConfig SFDefaultEventQueueConfig = {
 - (instancetype)initWithRootDirPath:(NSString *)rootDirPath {
     self = [super init];
     if (self) {
-        _sdkVersion = @"v2.0.0";
+        _sdkVersion = @"v2.0.1";
 
         _rootDirPath = rootDirPath;
 

--- a/Sift/SiftIosAppState.h
+++ b/Sift/SiftIosAppState.h
@@ -7,7 +7,7 @@
 #import "SiftHtDictionary.h"
 #import "SiftUtils.h"
 
-SiftHtDictionary *SFMakeEmptyIosAppState();
+SiftHtDictionary *SFMakeEmptyIosAppState(void);
 
 SiftHtDictionary *SFCollectIosAppState(CLLocationManager *locationManager, NSString *title);
 

--- a/Sift/SiftIosAppState.m
+++ b/Sift/SiftIosAppState.m
@@ -251,7 +251,7 @@ SiftHtDictionary *SFCMMagnetometerDataToDictionary(CMMagnetometerData *data, SFT
 
 #pragma mark - App state collection.
 
-static SF_GENERICS(NSArray, NSString *) *getIpAddresses();
+static SF_GENERICS(NSArray, NSString *) *getIpAddresses(void);
 
 SiftHtDictionary *SFCollectIosAppState(CLLocationManager *locationManager, NSString *title) {
     SiftHtDictionary *iosAppState = SFMakeEmptyIosAppState();

--- a/Sift/SiftIosDeviceProperties.h
+++ b/Sift/SiftIosDeviceProperties.h
@@ -4,6 +4,6 @@
 
 #import "SiftHtDictionary.h"
 
-SiftHtDictionary *SFMakeEmptyIosDeviceProperties();
+SiftHtDictionary *SFMakeEmptyIosDeviceProperties(void);
 
-SiftHtDictionary *SFCollectIosDeviceProperties();
+SiftHtDictionary *SFCollectIosDeviceProperties(void);


### PR DESCRIPTION
## Purpose:
To remove all the warnings reported during build of iOS SDK. This creates some inconvenience for customer's iOS app development team when these warnings shows up during their own iOS app development.

## Technical overview:
Fix all the warnings. In most cases XCode itself fixes these warnings.

## Testing plan:
- [x] This PR contains all required labels and reviewers as per our [Change Management Procedure](https://paper.dropbox.com/doc/Change-Management-Procedure--AaNgGK8kKaT7WkLgDgPbFIDnAg-IvGDETLPhSFM3t6198IhG#:uid=669926417316840&h2=Types-of-Review-for-Changes)
- [x] Local Testing (Passing unit test-cases, Local testing where iphone simulator sending events)

## Deployment plan:
Release a new version of iOS SDK as per 

## Rollback plan:
- Revert your changes on master and rollback to previous release.

## Customer Impact Assessment:
- as per our [Change Management Procedure](https://paper.dropbox.com/doc/Change-Management-Procedure--AaNgGK8kKaT7WkLgDgPbFIDnAg-IvGDETLPhSFM3t6198IhG#:uid=669926417316840&h2=Types-of-Review-for-Changes)
- Severity 3 (This PR is just fixing the warnings during build)