### PR TITLE
[MSUE-88] Expose and enable public collect method for iOS SDK

### DIFF
--- a/HelloSift/HelloSift/Base.lproj/Main.storyboard
+++ b/HelloSift/HelloSift/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11542" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19142.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19129"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -37,8 +35,16 @@
                                     <action selector="handleUserIdChanged:" destination="BYZ-38-t0r" eventType="editingChanged" id="2pJ-Dj-qrd"/>
                                 </connections>
                             </textField>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UGH-ab-39w" userLabel="Button Request Upload">
-                                <rect key="frame" x="16" y="407" width="343" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KzO-lO-dMV" userLabel="Button Request Collect">
+                                <rect key="frame" x="17" y="389" width="343" height="30"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Collect"/>
+                                <connections>
+                                    <action selector="collectButtonClicked:" destination="BYZ-38-t0r" eventType="touchUpInside" id="dxO-F7-7QK"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UGH-ab-39w" userLabel="Button Request Upload">
+                                <rect key="frame" x="17" y="438" width="343" height="30"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Upload"/>
                                 <connections>

--- a/HelloSift/HelloSift/ViewController.m
+++ b/HelloSift/HelloSift/ViewController.m
@@ -73,6 +73,10 @@
     void (*setterFunc)(id, SEL, NSString*) = (void *)[[Sift sharedInstance] methodForSelector:setter];
     setterFunc([Sift sharedInstance], setter, newValue);
 }
+- (IBAction)collectButtonClicked:(id)sender {
+    NSLog(@"Button \"Request Collect\" was clicked");
+    [[Sift sharedInstance] collect];
+}
 
 - (IBAction)handleRequestUploadButtonClick:(id)sender {
     NSLog(@"Button \"Request Upload\" was clicked");

--- a/Sift/Sift.h
+++ b/Sift/Sift.h
@@ -70,6 +70,11 @@ NS_EXTENSION_UNAVAILABLE_IOS("Sift is not supported for iOS extensions.")
 - (void)unsetUserId;
 
 /**
+ * Use this method to collect mobile events at your discretion
+ */
+- (void)collect;
+
+/**
  * @name Configurations.
  *
  * You should configure `accountId`, `beaconKey`, and `userId`.

--- a/Sift/Sift.m
+++ b/Sift/Sift.m
@@ -165,6 +165,11 @@ static const SiftQueueConfig SFDefaultEventQueueConfig = {
     }
 }
 
+- (void)collect {
+    [_iosDevicePropertiesCollector collect];
+    [_iosAppStateCollector collectWithTitle:nil andTimestamp:SFCurrentTime()];
+}
+
 - (BOOL)upload {
     return [self upload:NO];
 }

--- a/Sift/SiftIosAppStateCollector+Private.h
+++ b/Sift/SiftIosAppStateCollector+Private.h
@@ -26,9 +26,6 @@
  */
 - (void)checkAndCollectWhenNoneRecently:(SFTimestamp)now NS_EXTENSION_UNAVAILABLE_IOS("checkAndCollectWhenNoneRecently is not supported for iOS extensions.");
 
-/** Collect app state. */
-- (void)collectWithTitle:(NSString *)title andTimestamp:(SFTimestamp)now NS_EXTENSION_UNAVAILABLE_IOS("collectWithTitle is not supported for iOS extensions.");
-
 /** @return YES if can collect Location data. */
 - (BOOL)canCollectLocationData;
 

--- a/Sift/SiftIosAppStateCollector.h
+++ b/Sift/SiftIosAppStateCollector.h
@@ -10,6 +10,9 @@
 
 - (void)archive;
 
+/** Collect app state. */
+- (void)collectWithTitle:(NSString *)title andTimestamp:(SFTimestamp)now NS_EXTENSION_UNAVAILABLE_IOS("collectWithTitle is not supported for iOS extensions.");
+
 /**
  * Because CMMotionManager is "almost" a global singleton object, we
  * have to coordinate that there is only one CMMotionManager instance

--- a/Sift/SiftIosDevicePropertiesCollector.h
+++ b/Sift/SiftIosDevicePropertiesCollector.h
@@ -6,6 +6,6 @@
 NS_EXTENSION_UNAVAILABLE_IOS("SiftIosDevicePropertiesCollector is not supported for iOS extensions.")
 @interface SiftIosDevicePropertiesCollector : NSObject
 
-// Nothing here - a collector is autonomous.
+- (void)collect;
 
 @end

--- a/SiftTests/SiftTests.m
+++ b/SiftTests/SiftTests.m
@@ -131,4 +131,17 @@
     XCTAssertTrue([_sift hasEventQueue: [_sift defaultQueueIdentifier]]);
 }
 
+- (void)testCollect {
+    SiftQueueConfig config = {
+        .uploadWhenMoreThan = 65536,
+        .uploadWhenOlderThan = 3600,
+    };
+    [_sift addEventQueue: @"sift-devprops" config: config];
+    
+    [_sift collect];
+    
+    XCTAssertTrue([_sift hasEventQueue: [_sift defaultQueueIdentifier]]);
+    XCTAssertTrue([_sift hasEventQueue: @"sift-devprops"]);
+}
+
 @end


### PR DESCRIPTION
1) Exposed collectWithTitle method of SiftIosAppStateCollector.
2) Expose collect method of SiftIosDevicePropertiesCollector.
3) Add a new collect method in Sift.
4) Added unit test case for the above.
5) End to end testing completed.
6) Added collect button in the sift-example.