### PR TITLE
Fix warnings in iOS mobile SDK (#124)

### DIFF
--- a/HelloSift/Cartfile
+++ b/HelloSift/Cartfile
@@ -1,1 +1,2 @@
-github "SiftScience/sift-ios" ~> 2.1.1
+git "file:///Users/intersmart/Documents/sift/sift-ios"
+

--- a/HelloSift/Cartfile.resolved
+++ b/HelloSift/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "SiftScience/sift-ios" "v2.1.1"
+git "file:///Users/intersmart/Documents/sift/sift-ios" "v2.1.1"

--- a/Sift/Sift.h
+++ b/Sift/Sift.h
@@ -2,11 +2,23 @@
 
 // This is a public header.
 
-#import <CoreMotion/CoreMotion.h>
-#import <Foundation/Foundation.h>
+@import CoreMotion;
+@import Foundation;
+
 
 #import "SiftEvent.h"
 #import "SiftQueueConfig.h"
+#import "SiftIosAppState.h"
+#import "SiftCircularBuffer.h"
+#import "NSData+GZIP.h"
+#import "SiftDebug.h"
+#import "SiftIosAppStateCollector.h"
+#import "SiftIosDevicePropertiesCollector.h"
+#import "TaskManager.h"
+#import "SiftEvent+Private.h"
+#import "SiftIosAppStateCollector+Private.h"
+#import "SiftTokenBucket.h"
+
 
 /**
  * This is the main interface you interact with Sift.

--- a/Sift/Sift.m
+++ b/Sift/Sift.m
@@ -3,19 +3,9 @@
 @import Foundation;
 @import UIKit;
 
-#import "SiftDebug.h"
-#import "SiftEvent.h"
-#import "SiftEvent+Private.h"
-#import "SiftIosAppStateCollector.h"
-#import "SiftIosDevicePropertiesCollector.h"
-#import "SiftQueue.h"
-#import "SiftQueueConfig.h"
-#import "SiftUploader.h"
-#import "SiftUtils.h"
-#import "TaskManager.h"
-
 #import "Sift.h"
-#import "Sift+Private.h"
+#import "SiftQueue.h"
+#import "SiftUploader.h"
 
 static NSString * const SFServerUrlFormat = @"https://api3.siftscience.com/v3/accounts/%@/mobile_events";
 

--- a/Sift/SiftQueueConfig.h
+++ b/Sift/SiftQueueConfig.h
@@ -2,7 +2,7 @@
 
 // This is a public header.
 
-#import <Foundation/Foundation.h>
+@import Foundation;
 
 /** Control the behavior of an `SFQueue`. */
 typedef struct {

--- a/Sift/SiftUploader.m
+++ b/Sift/SiftUploader.m
@@ -3,13 +3,8 @@
 @import Foundation;
 @import UIKit;
 
-#import "NSData+GZIP.h"
-#import "SiftDebug.h"
-#import "SiftEvent.h"
-#import "SiftEvent+Private.h"
-#import "TaskManager.h"
-
 #import "SiftUploader.h"
+#import "Sift.h"
 
 @implementation SiftUploader {
     TaskManager *_taskManager;


### PR DESCRIPTION
This commit addresses the issue by adding #import ".h" to the umbrella header.