### PR TITLE
[MSUE-124] Fix warnings in iOS mobile SDK

### DIFF
--- a/Sift/Sift.h
+++ b/Sift/Sift.h
@@ -7,6 +7,20 @@
 
 #import "SiftEvent.h"
 #import "SiftQueueConfig.h"
+#import "TaskManager.h"
+#import "SiftCircularBuffer.h"
+#import "NSData+GZIP.h"
+#import "SiftEvent+Private.h"
+#import "SiftIosAppState.h"
+#import "SiftIosDeviceProperties.h"
+#import "SiftDebug.h"
+#import "SiftIosAppStateCollector+Private.h"
+#import "SiftIosDevicePropertiesCollector.h"
+#import "SiftTokenBucket.h"
+#import "SiftUploader.h"
+#import "SiftQueue.h"
+
+
 
 /**
  * This is the main interface you interact with Sift.

--- a/Sift/SiftUploader.h
+++ b/Sift/SiftUploader.h
@@ -2,7 +2,8 @@
 
 @import Foundation;
 
-#import "Sift.h"
+//#import "Sift.h"
+@class Sift;
 
 NS_EXTENSION_UNAVAILABLE_IOS("SiftUploader is not supported for iOS extensions.")
 @interface SiftUploader : NSObject <NSURLSessionTaskDelegate, NSURLSessionDataDelegate>

--- a/Sift/SiftUploader.m
+++ b/Sift/SiftUploader.m
@@ -8,7 +8,7 @@
 #import "SiftEvent.h"
 #import "SiftEvent+Private.h"
 #import "TaskManager.h"
-
+#import "Sift.h"
 #import "SiftUploader.h"
 
 @implementation SiftUploader {


### PR DESCRIPTION
**Purpose**

To fix warnings in iOS mobile SDK

**Summary**

The umbrella header is a header file that includes all of the other headers for a module, and it is used to make it easier for other modules to import the headers they need from the module. To fix this warning, reference the ".h" file in the umbrella header for the module.

**Testing** 

To ensure compatibility with the latest version of Xcode, the software was thoroughly tested by building and running it on Xcode Version 14.2

<img width="375" alt="Screenshot 2023-04-10 at 3 13 48 PM" src="https://user-images.githubusercontent.com/8215897/230877720-18d77bdd-80c9-44fc-b849-bf12d6257104.png">







