### PR TITLE
Remove reference to HackerNewsReader submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "samples/HackerNewsReader"]
-	path = samples/HackerNewsReader
-	url = https://github.com/SiftScience/HackerNewsReader.git


### PR DESCRIPTION
This PR removes the outdated reference to the HackerNewsReader repo.