### PR TITLE
Allow sending mobile sdk events to multiple SIFT instances

### DIFF
--- a/Sift/AccountKey.h
+++ b/Sift/AccountKey.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+
+@interface AccountKey : NSObject
+
+@property NSString *accountId;
+@property NSString *beaconKey;
+
+@end

--- a/Sift/AccountKey.m
+++ b/Sift/AccountKey.m
@@ -1,0 +1,5 @@
+#import "AccountKey.h"
+
+@implementation AccountKey
+
+@end

--- a/Sift/Sift.h
+++ b/Sift/Sift.h
@@ -7,6 +7,7 @@
 
 #import "SiftEvent.h"
 #import "SiftQueueConfig.h"
+#import "AccountKey.h"
 
 /**
  * This is the main interface you interact with Sift.
@@ -100,6 +101,13 @@ NS_EXTENSION_UNAVAILABLE_IOS("Sift is not supported for iOS extensions.")
  * NOTE: This is persisted to device's storage.
  */
 @property NSString *beaconKey;
+
+/**
+ * Account Keys.  Default to nil. Used to send data to multiple accountId, beaconkey.
+ *
+ * NOTE: This is persisted to device's storage.
+ */
+@property NSArray<AccountKey *> *accountKeys;
 
 /**
  * User ID.  Default to nil.

--- a/Sift/Sift.m
+++ b/Sift/Sift.m
@@ -13,6 +13,7 @@
 #import "SiftUploader.h"
 #import "SiftUtils.h"
 #import "TaskManager.h"
+#import "AccountKey.h"
 
 #import "Sift.h"
 #import "Sift+Private.h"
@@ -34,6 +35,7 @@ static const SiftQueueConfig SFDefaultEventQueueConfig = {
 
     NSString *_accountId;
     NSString *_beaconKey;
+    NSArray<AccountKey *> *_accountKeys;
     NSString *_userId;
 
     NSMutableDictionary *_eventQueues;
@@ -201,8 +203,6 @@ static const SiftQueueConfig SFDefaultEventQueueConfig = {
     return YES;
 }
 
-#pragma mark - Account keys
-
 - (NSString *)accountId {
     return _accountId;
 }
@@ -221,6 +221,15 @@ static const SiftQueueConfig SFDefaultEventQueueConfig = {
     [self archiveKeys];
 }
 
+- (NSArray<AccountKey *> *)accountKeys {
+    return _accountKeys;
+}
+
+- (void)setAccountKeys:(NSArray<AccountKey *> *)accountKeys {
+    _accountKeys = accountKeys;
+    [self archiveKeys];
+}
+
 - (NSString *)userId {
     return _userId;
 }
@@ -235,7 +244,6 @@ static const SiftQueueConfig SFDefaultEventQueueConfig = {
     [self archiveKeys];
 }
 
-
 - (BOOL)disallowCollectingLocationData {
     return [_iosAppStateCollector disallowCollectingLocationData];
 }
@@ -244,12 +252,11 @@ static const SiftQueueConfig SFDefaultEventQueueConfig = {
     [_iosAppStateCollector setDisallowCollectingLocationData:disallowCollectingLocationData];
 }
 
-#pragma mark - NSKeyedArchiver/NSKeyedUnarchiver
-
 static NSString * const SF_SIFT = @"sift";
 static NSString * const SF_SIFT_ACCOUNT_ID = @"accountId";
 static NSString * const SF_SIFT_BEACON_KEY = @"beaconKey";
 static NSString * const SF_SIFT_USER_ID = @"userId";
+static NSString * const SF_SIFT_ACCOUNT_KEYS = @"accountKeys";
 
 static NSString * const SF_QUEUE_DIR = @"queues";
 static NSString * const SF_IOS_APP_STATE_COLLECTOR = @"ios_app_state_collector";
@@ -290,6 +297,9 @@ static NSString * const SF_UPLOADER = @"uploader";
     if (_beaconKey) {
         [archive setObject:_beaconKey forKey:SF_SIFT_BEACON_KEY];
     }
+    if (_accountKeys) {
+        [archive setObject:_accountKeys forKey:SF_SIFT_ACCOUNT_KEYS];
+    }
     if (_userId) {
         [archive setObject:_userId forKey:SF_SIFT_USER_ID];
     }
@@ -316,13 +326,15 @@ static NSString * const SF_UPLOADER = @"uploader";
     if (archive) {
         _accountId = [archive objectForKey:SF_SIFT_ACCOUNT_ID];
         _beaconKey = [archive objectForKey:SF_SIFT_BEACON_KEY];
+        _accountKeys = [archive objectForKey:SF_SIFT_ACCOUNT_KEYS];
         _userId = [archive objectForKey:SF_SIFT_USER_ID];
     } else {
         _accountId = nil;
         _beaconKey = nil;
+        _accountKeys = nil;
         _userId = nil;
     }
-    SF_DEBUG(@"Unarchive: accountId=%@ beaconKey=%@ userId=%@", _accountId, _beaconKey, _userId);
+    SF_DEBUG(@"Unarchive: accountId=%@ beaconKey=%@ accountKeys=%@ userId=%@", _accountId, _beaconKey, _accountKeys, _userId);
 }
 
 @end

--- a/SiftTests/MultiUploaderTest.m
+++ b/SiftTests/MultiUploaderTest.m
@@ -1,0 +1,118 @@
+// Copyright (c) 2016 Sift Science. All rights reserved.
+
+@import XCTest;
+
+#import "SiftEvent.h"
+#import "Sift.h"
+#import "Sift+Private.h"
+
+#import "SiftUploader.h"
+
+#import "SiftStubHttpProtocol.h"
+
+@interface SiftEventFileMultiUploaderTests : XCTestCase
+
+@end
+
+@implementation SiftEventFileMultiUploaderTests {
+    Sift *_sift;
+    SiftUploader *_uploader;
+}
+
+- (void)setUp {
+    [super setUp];
+
+    _sift = [[Sift alloc] init];  // Don't call initWithRootDirPath.
+    _sift.accountId = @"account_id_1";
+    _sift.beaconKey = @"beacon_key_1";
+    
+    AccountKey *accountKey1 = [AccountKey new];
+    accountKey1.accountId = @"account_id_2";
+    accountKey1.beaconKey = @"beacon_key_2";
+
+    AccountKey *accountKey2 = [AccountKey new];
+    accountKey2.accountId = @"account_id_3";
+    accountKey2.beaconKey = @"beacon_key_3";
+    
+    NSArray<AccountKey *> *accountKeysArray = @[accountKey1, accountKey2];
+    
+    _sift.accountKeys = accountKeysArray;
+    _sift.userId = @"user_id";
+    _sift.serverUrlFormat = @"mock+https://127.0.0.1/v3/accounts/%@/mobile_events";
+
+    // Disable exponential backoff with baseoffBase = 0.
+    _uploader = [[SiftUploader alloc] initWithArchivePath:nil sift:_sift config:SFMakeStubConfig() backoffBase:0];
+
+    SFHttpStub *stub = [SFHttpStub sharedInstance];
+    [stub.stubbedStatusCodes removeAllObjects];
+    [stub.capturedRequests removeAllObjects];
+}
+
+- (void)tearDown {
+    [super tearDown];
+}
+
+- (void)testUpload {
+    SFHttpStub *stub = [SFHttpStub sharedInstance];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for upload tasks completion"];
+    stub.completionHandler = ^{
+        [expectation fulfill];
+    };
+
+    [stub.stubbedStatusCodes addObject:@200];
+    [stub.stubbedStatusCodes addObject:@200];
+    [stub.stubbedStatusCodes addObject:@200];
+
+    NSArray *events = @[[SiftEvent eventWithType:nil path:@"path" fields:nil]];
+    [_uploader upload:events];
+
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+
+    XCTAssertEqual(stub.stubbedStatusCodes.count, 0);
+    XCTAssertEqual(stub.capturedRequests.count, 3);
+}
+
+- (void)testUploadRejected {
+    SFHttpStub *stub = [SFHttpStub sharedInstance];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for upload tasks completion"];
+    stub.completionHandler = ^{
+        [expectation fulfill];
+    };
+
+    // SFUploader takes three rejects.
+    [stub.stubbedStatusCodes addObject:@500];
+    [stub.stubbedStatusCodes addObject:@500];
+    [stub.stubbedStatusCodes addObject:@500];
+
+    NSArray *events = @[[SiftEvent eventWithType:nil path:@"path" fields:nil]];
+    [_uploader upload:events];
+
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+
+    XCTAssertEqual(stub.stubbedStatusCodes.count, 0);
+    XCTAssertEqual(stub.capturedRequests.count, 3);
+}
+
+- (void)testUploadHttpError {
+    SFHttpStub *stub = [SFHttpStub sharedInstance];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for upload tasks completion"];
+    stub.completionHandler = ^{
+        [expectation fulfill];
+    };
+
+    [stub.stubbedStatusCodes addObject:@400];
+    [stub.stubbedStatusCodes addObject:@400];
+    [stub.stubbedStatusCodes addObject:@400];
+
+    NSArray *events = @[[SiftEvent eventWithType:nil path:@"path" fields:nil]];
+    [_uploader upload:events];
+
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+
+    XCTAssertEqual(stub.capturedRequests.count, 3);
+}
+
+@end

--- a/SiftTests/SiftTests.m
+++ b/SiftTests/SiftTests.m
@@ -3,7 +3,6 @@
 @import XCTest;
 
 #import "SiftUtils.h"
-
 #import "Sift.h"
 #import "Sift+Private.h"
 #import "SiftIosAppStateCollector.h"
@@ -79,6 +78,20 @@
 - (void)testSetBeaconKey {
     [_sift setBeaconKey:@"xxxx"];
     XCTAssertEqual(_sift.beaconKey, @"xxxx");
+}
+
+- (void)testSetAccountKeys {
+    AccountKey *accountKey1 = [AccountKey new];
+    accountKey1.accountId = @"accountId1";
+    accountKey1.beaconKey = @"beaconKey1";
+
+    AccountKey *accountKey2 = [AccountKey new];
+    accountKey2.accountId = @"accountId2";
+    accountKey2.beaconKey = @"beaconKey2";
+
+    NSArray<AccountKey *> *accountKeysArray = @[accountKey1, accountKey2];
+    [_sift setAccountKeys:accountKeysArray];
+    XCTAssertEqual(_sift.accountKeys, accountKeysArray);
 }
 
 - (void)testSetUserId {


### PR DESCRIPTION
# Purpose
Allow sending mobile sdk events to multiple SIFT accounts. Example scenario:

There is a global SIFT account & a regional SIFT account (let's say APAC - Asia Pacific). We want to :

send mobile sdk events to global SIFT account for non APAC users
send mobile sdk events to both global SIFT & APAC SIFT accounts for APAC users.
At the moment, SIFT sdk only allows sending mobile app events to single SIFT account. This PR will make the SDK flexible to allow sending events to multiple SIFT accounts.

# Technical Detail
The changes are made to support backward compatibility so the existing clients will still be able to use single SIFT account just like before:
```
Sift *sift = [Sift sharedInstance];
[sift setAccountId:@"YOUR_ACCOUNT_ID"];
[sift setBeaconKey:@"YOUR_JAVASCRIPT_SNIPPET_KEY"];
```

Now we allow initializing the SDK like this as well:
```
AccountKey *accountKey1 = [AccountKey new];
accountKey1.accountId = @"accountId1";
accountKey1.beaconKey = @"beaconKey1";

AccountKey *accountKey2 = [AccountKey new];
accountKey2.accountId = @"accountId2";
accountKey2.beaconKey = @"beaconKey2";

Sift *sift = [Sift sharedInstance];
NSArray<AccountKey *> *accountKeys = @[accountKey1, accountKey2];
[sift setAccountKeys:accountKeys];
```
# Testing details
Added unit tests
