### PR TITLE
Automating the sift ios releases.

### DIFF
--- a/.github/workflows/ios_cocopod_release.yml
+++ b/.github/workflows/ios_cocopod_release.yml
@@ -1,0 +1,22 @@
+name: Release CocoaPod to CocoaPods.org
+
+on:
+  release:
+    types: [published]
+
+env:
+  GH_TOKEN: ${{ github.token }}
+  COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+
+
+jobs:
+  release:
+    name: Perform the Release
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Publish to CocoaPods
+        run: pod trunk push Sift.podspec

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .DS_Store
 
 xcuserdata
-
+**/.idea
 # Carthage
 #
 # Add this line if you want to avoid checking in source code from Carthage dependencies.


### PR DESCRIPTION
## Purpose:
- https://sift.atlassian.net/browse/CI-13307
- https://sift.atlassian.net/wiki/spaces/RNDTEAM/pages/743309462/sift-ios+runbook#CocoaPods-Troubleshooting

## Testing:
- This needs macos-latest base image, couldn't pull this locally. https://github.com/actions/runner-images#available-images
- Can keep the release command uncommented. https://stackoverflow.com/questions/25604601/how-to-do-pod-trunk-push-to-replace-an-existing-version-of-podspec/44317506#44317506
