### PR TITLE
[API-7690] Fixes infinite retries for network errors

### DIFF
--- a/Sift/SiftUploader.m
+++ b/Sift/SiftUploader.m
@@ -98,6 +98,7 @@ static const int64_t SF_CHECK_UPLOAD_LEEWAY = 5 * NSEC_PER_SEC;
         BOOL success = NO;
         if (error) {
             SF_IMPORTANT(@"Could not complete upload due to %@", [error localizedDescription]);
+            self->_numRejects++;
         } else {
             NSInteger statusCode = [(NSHTTPURLResponse *)task.response statusCode];
             SF_DEBUG(@"PUT %@ status %ld", task.response.URL, (long)statusCode);

--- a/SiftTests/SiftStubHttpProtocol.m
+++ b/SiftTests/SiftStubHttpProtocol.m
@@ -60,10 +60,16 @@ NSURLSessionConfiguration *SFMakeStubConfig(void) {
         [stub.stubbedStatusCodes removeObjectAtIndex:0];
     }
 
-    NSURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.request.URL statusCode:statusCode HTTPVersion:@"HTTP/1.1" headerFields:nil];
-    [self.client URLProtocol:self didReceiveResponse:response cacheStoragePolicy:NSURLCacheStorageAllowedInMemoryOnly];
-    [self.client URLProtocolDidFinishLoading:self];
-
+    // Status code 1 hardcoded for network errors.
+    if (statusCode == 1) {
+        NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorUnknown userInfo:nil];
+        [self.client URLProtocol:self didFailWithError:error];
+        [self.client URLProtocolDidFinishLoading:self];
+    } else {
+        NSURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.request.URL statusCode:statusCode HTTPVersion:@"HTTP/1.1" headerFields:nil];
+        [self.client URLProtocol:self didReceiveResponse:response cacheStoragePolicy:NSURLCacheStorageAllowedInMemoryOnly];
+        [self.client URLProtocolDidFinishLoading:self];
+    }
     if (!stub.stubbedStatusCodes.count) {
         stub.completionHandler();
     }

--- a/SiftTests/SiftUploaderTests.m
+++ b/SiftTests/SiftUploaderTests.m
@@ -78,7 +78,7 @@
     [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
     XCTAssertEqual(stub.stubbedStatusCodes.count, 0);
-    XCTAssertEqual(stub.capturedRequests.count, 3);
+    XCTAssertEqual(stub.capturedRequests.count, 2);
 }
 
 - (void)testUploadHttpError {
@@ -97,6 +97,58 @@
     [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
     XCTAssertEqual(stub.capturedRequests.count, 1);
+}
+
+- (void)testUploadWithNetworkError {
+    SFHttpStub *stub = [SFHttpStub sharedInstance];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for upload tasks completion"];
+    stub.completionHandler = ^{
+        [expectation fulfill];
+    };
+
+    int rejectedLimitCount = 3;
+    for (int i = 0; i < rejectedLimitCount; i++) {
+        // Simulate a network error response (status code 1 hardcoded for network errors).
+        [stub.stubbedStatusCodes addObject:@1];
+    }
+
+    NSArray *events = @[[SiftEvent eventWithType:nil path:@"path" fields:nil]];
+    [_uploader upload:events];
+
+    [self waitForExpectationsWithTimeout:3.0 handler:nil];
+
+    XCTAssertEqual(stub.capturedRequests.count, rejectedLimitCount);
+    XCTAssertEqual(stub.stubbedStatusCodes.count, 0);
+}
+
+- (void)testUploadWithNetworkErrorAndTimeout {
+    SFHttpStub *stub = [SFHttpStub sharedInstance];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for upload tasks completion"];
+    stub.completionHandler = ^{
+        [expectation fulfill];
+    };
+    
+    int rejectedLimitCount = 4;
+    for (int i = 0; i < rejectedLimitCount; i++) {
+        // Simulate a network error response (status code 1 hardcoded for network errors).
+        [stub.stubbedStatusCodes addObject:@1];
+    }
+    
+    NSArray *events = @[[SiftEvent eventWithType:nil path:@"path" fields:nil]];
+    [_uploader upload:events];
+    
+    XCTWaiter *waiter = [[XCTWaiter alloc] init];
+    XCTWaiterResult result = [waiter waitForExpectations:@[expectation] timeout:3.0];
+    
+    // The waiter should time out because it's waiting for the final call (call 4) to be made.
+    // However, the call is not made because the system stops retrying after three failed attempts (SF_REJECT_LIMIT).
+    XCTAssertEqual(result, XCTWaiterResultTimedOut);
+    // Assert that no more than 3(SF_REJECT_LIMIT) calls were made
+    XCTAssertEqual(stub.capturedRequests.count, 3);
+    // 1 stub should still be in the queue
+    XCTAssertEqual(stub.stubbedStatusCodes.count, 1);
 }
 
 @end

--- a/SiftTests/SiftUploaderTests.m
+++ b/SiftTests/SiftUploaderTests.m
@@ -78,7 +78,7 @@
     [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
     XCTAssertEqual(stub.stubbedStatusCodes.count, 0);
-    XCTAssertEqual(stub.capturedRequests.count, 2);
+    XCTAssertEqual(stub.capturedRequests.count, 3);
 }
 
 - (void)testUploadHttpError {


### PR DESCRIPTION
## Purpose
In case of any network errors task was infinitely in the loop trying to connect to the server.

## Summary
Added increment for the numRetries variable to break infinite loop

## Testing
Local testing and unit tests

## Checklist
- [x] The change was thoroughly tested manually
- [x] The change was covered with unit tests
- [x] The change was tested with the integration example
- [ ] Necessary changes were made in the integration example (if applicable)
- [ ] New functionality is reflected in README (if applicable)
