### PR TITLE
Adds Public headers for Swift Package. #114

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,8 @@ let package = Package(
             resources: [
                 .process("../PrivacyInfo.xcprivacy")
             ],
-            publicHeadersPath: "."),
+            publicHeadersPath: "Public"
+        ),
         .testTarget(
             name: "sift-iosTests",
             dependencies: ["sift-ios"]),

--- a/Sift/Public/Sift.h
+++ b/Sift/Public/Sift.h
@@ -1,0 +1,4 @@
+#import "../SiftEvent.h"
+#import "../SiftQueueConfig.h"
+#import "../Sift.h"
+#import "../SiftCompatibility.h"


### PR DESCRIPTION
## Purpose
Resolves umbrella warning when Sift is integrated by SPM. #114 

## Summary

### Root cause
1. Swift package does not support root source folder as a folder for public headers.

### Solution
Created dedicated folder and header file for required public headers
New header file is specific for Swift Package only, that is why it is not included into the project file.

## Testing

### Step to reproduce
1. Create New Static Library project. Use 
2. Add `sift-ios` through the Package Dependencies
3. Add `import Sift`to swift file
4. Build target

## Checklist
- [x] The change was thoroughly tested manually
- [x] The change was covered with unit tests (Not applicable)
- [x] The change was tested with the integration example (Not applicable)
- [x] Necessary changes were made in the integration example (Not applicable)
- [x] New functionality is reflected in README (Not applicable)
