### PR TITLE
Fix SiftUploader unit-tests

### DIFF
--- a/Sift/SiftUploader.h
+++ b/Sift/SiftUploader.h
@@ -9,9 +9,6 @@ NS_EXTENSION_UNAVAILABLE_IOS("SiftUploader is not supported for iOS extensions."
 
 - (instancetype)initWithArchivePath:(NSString *)archivePath sift:(Sift *)sift;
 
-/** For testing. */
-- (instancetype)initWithArchivePath:(NSString *)archivePath sift:(Sift *)sift config:(NSURLSessionConfiguration *)config backoffBase:(int64_t)backoffBase networkRetryTimeout:(int64_t)networkRetryTimeout;
-
 /** Persist uploader state to disk. */
 - (void)archive;
 

--- a/SiftTests/SiftUploaderTests.m
+++ b/SiftTests/SiftUploaderTests.m
@@ -10,6 +10,11 @@
 
 #import "SiftStubHttpProtocol.h"
 
+@interface SiftUploader (Testing)
+/** For testing. */
+- (instancetype)initWithArchivePath:(NSString *)archivePath sift:(Sift *)sift config:(NSURLSessionConfiguration *)config backoffBase:(int64_t)backoffBase networkRetryTimeout:(int64_t)networkRetryTimeout;
+@end
+
 @interface SiftEventFileUploaderTests : XCTestCase
 
 @end
@@ -29,7 +34,7 @@
     _sift.serverUrlFormat = @"mock+https://127.0.0.1/v3/accounts/%@/mobile_events";
 
     // Disable exponential backoff with baseoffBase = 0.
-    _uploader = [[SiftUploader alloc] initWithArchivePath:nil sift:_sift config:SFMakeStubConfig() backoffBase:0 networkRetryTimeout: 60 * NSEC_PER_SEC];
+    _uploader = [[SiftUploader alloc] initWithArchivePath:nil sift:_sift config:SFMakeStubConfig() backoffBase:NSEC_PER_SEC/100 networkRetryTimeout: NSEC_PER_SEC / 1000];
 
     SFHttpStub *stub = [SFHttpStub sharedInstance];
     [stub.stubbedStatusCodes removeAllObjects];
@@ -37,6 +42,8 @@
 }
 
 - (void)tearDown {
+    _uploader = nil;
+    _sift = nil;
     [super tearDown];
 }
 


### PR DESCRIPTION
## Purpose
Fixes crashing test setup in SiftUploaderTests
No new functionality

## Checklist
- [x] The change was thoroughly tested manually
- [x] The change was covered with unit tests
- [x] The change was tested with the integration example (not applicable)
- [x] Necessary changes were made in the integration example (if applicable)
- [x] New functionality is reflected in README (if applicable)
