### PR TITLE
MSUE-220: Stores first ifv to keychain

### DIFF
--- a/Sift.xcodeproj/project.pbxproj
+++ b/Sift.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0541A85D2D3E3A5F00076F57 /* SiftKeychain.h in Headers */ = {isa = PBXBuildFile; fileRef = 0541A85B2D3E3A5F00076F57 /* SiftKeychain.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0541A85E2D3E3A5F00076F57 /* SiftKeychain.m in Sources */ = {isa = PBXBuildFile; fileRef = 0541A85C2D3E3A5F00076F57 /* SiftKeychain.m */; };
+		0541A8602D3E3BAB00076F57 /* SiftKeychainTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0541A85F2D3E3BAB00076F57 /* SiftKeychainTests.m */; };
+		0541A8632D3E3D9400076F57 /* XCTestCase+Swizzling.m in Sources */ = {isa = PBXBuildFile; fileRef = 0541A8622D3E3D9400076F57 /* XCTestCase+Swizzling.m */; };
 		1E409D2425E173B20066C922 /* NSData+GZIP.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E409D2225E173B10066C922 /* NSData+GZIP.m */; };
 		1E409D2525E173B20066C922 /* NSData+GZIP.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E409D2325E173B20066C922 /* NSData+GZIP.h */; };
 		5E819393268E1A47007FED87 /* TaskManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E819391268E1A47007FED87 /* TaskManager.h */; };
@@ -63,6 +67,12 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0541A85B2D3E3A5F00076F57 /* SiftKeychain.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SiftKeychain.h; sourceTree = "<group>"; };
+		0541A85C2D3E3A5F00076F57 /* SiftKeychain.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SiftKeychain.m; sourceTree = "<group>"; };
+		0541A85F2D3E3BAB00076F57 /* SiftKeychainTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SiftKeychainTests.m; sourceTree = "<group>"; };
+		0541A8612D3E3D9400076F57 /* XCTestCase+Swizzling.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTestCase+Swizzling.h"; sourceTree = "<group>"; };
+		0541A8622D3E3D9400076F57 /* XCTestCase+Swizzling.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "XCTestCase+Swizzling.m"; sourceTree = "<group>"; };
+		0541A8642D3E49D500076F57 /* SiftKeychain+Testing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SiftKeychain+Testing.h"; sourceTree = "<group>"; };
 		1E409D2225E173B10066C922 /* NSData+GZIP.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+GZIP.m"; sourceTree = "<group>"; };
 		1E409D2325E173B20066C922 /* NSData+GZIP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+GZIP.h"; sourceTree = "<group>"; };
 		5E819391268E1A47007FED87 /* TaskManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TaskManager.h; sourceTree = "<group>"; };
@@ -169,6 +179,8 @@
 				8B5874F42552FE0C00CF8A02 /* SiftIosAppStateCollector+Private.h */,
 				713D85981D627E860011D5FE /* SiftIosDeviceProperties.h */,
 				713D85991D627E9F0011D5FE /* SiftIosDeviceProperties.m */,
+				0541A85B2D3E3A5F00076F57 /* SiftKeychain.h */,
+				0541A85C2D3E3A5F00076F57 /* SiftKeychain.m */,
 				7168EE321C864A4100A88245 /* SiftIosDevicePropertiesCollector.h */,
 				7168EE331C864A4100A88245 /* SiftIosDevicePropertiesCollector.m */,
 				7168EE1D1C7E7A6800A88245 /* SiftQueue.h */,
@@ -204,6 +216,10 @@
 				7168EE401C88C91900A88245 /* SiftUploaderTests.m */,
 				713AF4231DA456740061B688 /* SiftUtilsTests.m */,
 				7168EE101C7B977500A88245 /* SiftTests.m */,
+				0541A85F2D3E3BAB00076F57 /* SiftKeychainTests.m */,
+				0541A8642D3E49D500076F57 /* SiftKeychain+Testing.h */,
+				0541A8612D3E3D9400076F57 /* XCTestCase+Swizzling.h */,
+				0541A8622D3E3D9400076F57 /* XCTestCase+Swizzling.m */,
 			);
 			path = SiftTests;
 			sourceTree = "<group>";
@@ -225,6 +241,7 @@
 				1E409D2525E173B20066C922 /* NSData+GZIP.h in Headers */,
 				71B1B5971D8C700C00EA9B17 /* SiftIosAppStateCollector.h in Headers */,
 				716BEB8B1C7D336B009C3706 /* SiftQueueConfig.h in Headers */,
+				0541A85D2D3E3A5F00076F57 /* SiftKeychain.h in Headers */,
 				7168EE1E1C7E7A6800A88245 /* SiftQueue.h in Headers */,
 				7168EE051C7B977500A88245 /* Sift.h in Headers */,
 				713D859B1D627EA60011D5FE /* SiftIosDeviceProperties.h in Headers */,
@@ -338,6 +355,7 @@
 				5E819394268E1A47007FED87 /* TaskManager.m in Sources */,
 				716BEB931C7D3695009C3706 /* Sift.m in Sources */,
 				71E15CF91D95C92300A0305C /* SiftCircularBuffer.m in Sources */,
+				0541A85E2D3E3A5F00076F57 /* SiftKeychain.m in Sources */,
 				7168EE281C7FB80C00A88245 /* SiftUploader.m in Sources */,
 				71E15CFD1D95D15900A0305C /* SiftTokenBucket.m in Sources */,
 				713D859A1D627E9F0011D5FE /* SiftIosDeviceProperties.m in Sources */,
@@ -363,6 +381,8 @@
 				7168EE1C1C7E61E900A88245 /* SiftEventTests.m in Sources */,
 				713D859D1D6CF69E0011D5FE /* SiftIosDevicePropertiesTests.m in Sources */,
 				7168EE241C7F99AF00A88245 /* SiftQueueTests.m in Sources */,
+				0541A8632D3E3D9400076F57 /* XCTestCase+Swizzling.m in Sources */,
+				0541A8602D3E3BAB00076F57 /* SiftKeychainTests.m in Sources */,
 				7168EE421C88C91900A88245 /* SiftUploaderTests.m in Sources */,
 				71B1B5911D8B31ED00EA9B17 /* SiftIosAppStateTests.m in Sources */,
 			);

--- a/Sift/SiftKeychain.h
+++ b/Sift/SiftKeychain.h
@@ -1,0 +1,13 @@
+//
+//  SiftKeychain.h
+//  Sift
+//
+//  Created by Anton Poluboiarynov on 20.01.2025.
+//  Copyright © 2025 Sift Science. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SiftKeychain : NSObject
++ (NSString *)processDeviceIFV:(NSString *)ifv;
+@end

--- a/Sift/SiftKeychain.m
+++ b/Sift/SiftKeychain.m
@@ -1,0 +1,61 @@
+//
+//  SiftKeychain.m
+//  Sift
+//
+//  Created by Anton Poluboiarynov on 20.01.2025.
+//  Copyright © 2025 Sift Science. All rights reserved.
+//
+
+#import "SiftKeychain.h"
+@import Security;
+
+static NSString* kSiftVendorIFVKeychainKey = @"com.sift.initial_device_ifv";
+
+@implementation SiftKeychain
+
++ (NSString *)processDeviceIFV:(NSString *)ifv {
+    NSString *storedIFVString = [self getStoredIFVString];
+    if (storedIFVString == nil && ifv == nil) {
+        return nil;
+    }
+
+    if (storedIFVString == nil) {
+        [self storeIFVString:ifv];
+        return ifv;
+    }
+
+    return storedIFVString;
+}
+
++ (NSString *)getStoredIFVString {
+    NSDictionary *query = @{
+        (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
+        (__bridge id)kSecAttrAccount: kSiftVendorIFVKeychainKey,
+        (__bridge id)kSecReturnData: (__bridge id)kCFBooleanTrue,
+        (__bridge id)kSecMatchLimit: (__bridge id)kSecMatchLimitOne
+    };
+
+    CFTypeRef result = NULL;
+    SecItemCopyMatching((__bridge CFDictionaryRef)query, &result);
+
+    NSString *storedIFVString = nil;
+    if (result) {
+        NSData *data = (__bridge_transfer NSData *)result;
+        storedIFVString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    }
+    return storedIFVString;
+}
+
++ (void)storeIFVString:(NSString *)ifv {
+    NSData *data = [ifv dataUsingEncoding:NSUTF8StringEncoding];
+    NSDictionary *query = @{
+        (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
+        (__bridge id)kSecAttrAccount: kSiftVendorIFVKeychainKey,
+        (__bridge id)kSecValueData: data
+    };
+
+    SecItemDelete((__bridge CFDictionaryRef)query);
+    SecItemAdd((__bridge CFDictionaryRef)query, NULL);
+}
+
+@end

--- a/SiftTests/SiftEventTests.m
+++ b/SiftTests/SiftEventTests.m
@@ -66,6 +66,7 @@
         @"evidence_dylds_present": NSArray.class,
         @"evidence_files_present": NSArray.class,
         @"sdk_version": NSString.class,
+        @"initial_device_ifv": NSString.class,
     };
     
     for (NSString *name in entryTypes) {

--- a/SiftTests/SiftKeychain+Testing.h
+++ b/SiftTests/SiftKeychain+Testing.h
@@ -1,0 +1,14 @@
+//
+//  SiftKeychain+Testing.h
+//  Sift
+//
+//  Created by Anton Poluboiarynov on 20.01.2025.
+//  Copyright © 2025 Sift Science. All rights reserved.
+//
+
+#import "SiftKeychain.h"
+
+@interface SiftKeychain ()
++ (NSString *)getStoredIFVString;
++ (void)storeIFVString:(NSString *)ifv;
+@end

--- a/SiftTests/SiftKeychainTests.m
+++ b/SiftTests/SiftKeychainTests.m
@@ -1,0 +1,86 @@
+//
+//  SiftKeychainTests.m
+//  SiftTests
+//
+//  Created by Anton Poluboiarynov on 20.01.2025.
+//  Copyright © 2025 Sift Science. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "XCTestCase+Swizzling.h"
+#import "SiftKeychain+Testing.h"
+
+@interface SiftKeychainTests : XCTestCase
+
+@end
+
+@implementation SiftKeychainTests
+
+- (void)setup {
+    Method storeIFV = class_getClassMethod([SiftKeychain class], @selector(storeIFVString:));
+    Method mockStoreIFV = class_getClassMethod([SiftKeychainTests class], @selector(mockStoreDeviceIFV));
+    
+    [self swizzleMethod:storeIFV withMethod:mockStoreIFV];
+}
+
+- (void)tearDown {
+    Method storeIFV = class_getClassMethod([SiftKeychain class], @selector(storeIFVString:));
+    Method mockStoreIFV = class_getClassMethod([SiftKeychainTests class], @selector(mockStoreDeviceIFV));
+    
+    [self swizzleMethod:storeIFV withMethod:mockStoreIFV];    
+}
+
+- (void)testProcessDeviceIFV_nilDeviceIFV {
+    Method getStoredDeviceIFV = class_getClassMethod([SiftKeychain class], @selector(getStoredIFVString));
+    Method mockGetStoredDeviceIFV = class_getClassMethod([SiftKeychainTests class], @selector(mockNilStoredDeviceIFV));
+
+    [self swizzleMethod:getStoredDeviceIFV withMethod:mockGetStoredDeviceIFV];
+
+    NSString *actual = [SiftKeychain processDeviceIFV:nil];
+
+    XCTAssertNil(actual);
+    
+    [self swizzleMethod:mockGetStoredDeviceIFV withMethod:getStoredDeviceIFV];
+}
+
+- (void)testProcessDeviceIFV_nilStoredDeviceIFV {
+    Method getStoredDeviceIFV = class_getClassMethod([SiftKeychain class], @selector(getStoredIFVString));
+    Method mockGetStoredDeviceIFV = class_getClassMethod([SiftKeychainTests class], @selector(mockNilStoredDeviceIFV));
+
+    [self swizzleMethod:getStoredDeviceIFV withMethod:mockGetStoredDeviceIFV];
+
+    NSString *deviceIFV = @"DEVICE-IFV";
+    NSString *actual = [SiftKeychain processDeviceIFV:deviceIFV];
+
+    XCTAssertEqual(actual, deviceIFV);
+    
+    [self swizzleMethod:mockGetStoredDeviceIFV withMethod:getStoredDeviceIFV];
+}
+
+- (void)testProcessDeviceIFV_changedDeviceIFV {
+    Method getStoredDeviceIFV = class_getClassMethod([SiftKeychain class], @selector(getStoredIFVString));
+    Method mockGetStoredDeviceIFV = class_getClassMethod([SiftKeychainTests class], @selector(mockChangedStoredDeviceIFV));
+
+    [self swizzleMethod:getStoredDeviceIFV withMethod:mockGetStoredDeviceIFV];
+
+    NSString *deviceIFV = @"DEVICE-IFV";
+    NSString *actual = [SiftKeychain processDeviceIFV:deviceIFV];
+
+    XCTAssertEqual(actual, @"CHANGED-DEVICE-IFV");
+    
+    [self swizzleMethod:mockGetStoredDeviceIFV withMethod:getStoredDeviceIFV];
+}
+
+// MARK: Mocks
+
++ (NSString *)mockNilStoredDeviceIFV {
+    return nil;
+}
+
++ (NSString *)mockChangedStoredDeviceIFV {
+    return @"CHANGED-DEVICE-IFV";
+}
+
++ (void)mockStoreDeviceIFV {}
+
+@end

--- a/SiftTests/XCTestCase+Swizzling.h
+++ b/SiftTests/XCTestCase+Swizzling.h
@@ -1,0 +1,16 @@
+//
+//  XCTestCase (Swizzling).h
+//  SiftTests
+//
+//  Created by Anton Poluboiarynov on 20.01.2025.
+//  Copyright © 2025 Sift Science. All rights reserved.
+//
+
+#import <objc/runtime.h>
+@import Security;
+@import XCTest;
+
+@interface XCTestCase (Swizzling)
+- (void) swizzleMethod:(Method)originalMethod withMethod:(Method)swizzledMethod;
+@end
+

--- a/SiftTests/XCTestCase+Swizzling.m
+++ b/SiftTests/XCTestCase+Swizzling.m
@@ -1,0 +1,22 @@
+//
+//  XCTestCase+Swizzling.m
+//  SiftTests
+//
+//  Created by Anton Poluboiarynov on 20.01.2025.
+//  Copyright © 2025 Sift Science. All rights reserved.
+//
+
+#import "XCTestCase+Swizzling.h"
+@import Security;
+@import XCTest;
+
+@implementation XCTestCase (Swizzling)
+
+- (void)swizzleMethod:(Method)originalMethod withMethod:(Method)swizzledMethod {
+    IMP m1_imp = method_getImplementation(originalMethod);
+    IMP m2_imp = method_getImplementation(swizzledMethod);
+    method_setImplementation(originalMethod, m2_imp);
+    method_setImplementation(swizzledMethod, m1_imp);
+}
+
+@end


### PR DESCRIPTION
## Purpose

Adds new property `initial_device_ifv` to track `device_ifv` changes between application reinstallations

https://sift.atlassian.net/browse/MSUE-220

## Checklist
- [x] The change was thoroughly tested manually
- [x] The change was covered with unit tests
- [x] The change was tested with the integration example
- [x] Necessary changes were made in the integration example (if applicable)
- [ ] New functionality is reflected in README (if applicable)
