### PR TITLE
[MSUE-231] - Removes batch retry when network request blocked by firewall

### DIFF
--- a/SiftTests/SiftStubHttpProtocol.m
+++ b/SiftTests/SiftStubHttpProtocol.m
@@ -59,10 +59,9 @@ NSURLSessionConfiguration *SFMakeStubConfig(void) {
         statusCode = ((NSNumber *)[stub.stubbedStatusCodes objectAtIndex:0]).intValue;
         [stub.stubbedStatusCodes removeObjectAtIndex:0];
     }
-
-    // Status code 1 hardcoded for network errors.
-    if (statusCode == 1) {
-        NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorUnknown userInfo:nil];
+    
+    NSError *error = [self errorForStatusCode:statusCode];
+    if (error != nil) {
         [self.client URLProtocol:self didFailWithError:error];
         [self.client URLProtocolDidFinishLoading:self];
     } else {
@@ -77,6 +76,24 @@ NSURLSessionConfiguration *SFMakeStubConfig(void) {
 
 - (void)stopLoading {
     // Nothing yet...
+}
+
+- (NSError *) errorForStatusCode: (int) statusCode {
+    switch (statusCode) {
+        case 1:
+            return [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorUnknown userInfo:nil];
+        case -1001:
+            return [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorTimedOut userInfo:nil];
+        case -1003:
+            return [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCannotFindHost userInfo:nil];
+        case -1004:
+            return [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCannotConnectToHost userInfo:nil];
+        case -1005:
+            return [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorNetworkConnectionLost userInfo:nil];
+        case -1006:
+            return [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorDNSLookupFailed userInfo:nil];
+    }
+    return nil;
 }
 
 @end

--- a/SiftTests/SiftUploaderTests.m
+++ b/SiftTests/SiftUploaderTests.m
@@ -13,6 +13,7 @@
 @interface SiftUploader (Testing)
 /** For testing. */
 - (instancetype)initWithArchivePath:(NSString *)archivePath sift:(Sift *)sift config:(NSURLSessionConfiguration *)config backoffBase:(int64_t)backoffBase networkRetryTimeout:(int64_t)networkRetryTimeout;
+- (BOOL)isNetworkBlockedError:(NSError*) error;
 @end
 
 @interface SiftEventFileUploaderTests : XCTestCase
@@ -34,7 +35,7 @@
     _sift.serverUrlFormat = @"mock+https://127.0.0.1/v3/accounts/%@/mobile_events";
 
     // Disable exponential backoff with baseoffBase = 0.
-    _uploader = [[SiftUploader alloc] initWithArchivePath:nil sift:_sift config:SFMakeStubConfig() backoffBase:NSEC_PER_SEC/100 networkRetryTimeout: NSEC_PER_SEC / 1000];
+    _uploader = [[SiftUploader alloc] initWithArchivePath:nil sift:_sift config:SFMakeStubConfig() backoffBase:NSEC_PER_SEC/1000 networkRetryTimeout: 60 * NSEC_PER_SEC/1000 ];
 
     SFHttpStub *stub = [SFHttpStub sharedInstance];
     [stub.stubbedStatusCodes removeAllObjects];
@@ -218,6 +219,45 @@
     
     XCTAssertEqual(stub.capturedRequests.count, rejectedLimitCount + successfullRequests + rejectedHttpErrorLimitCount);
     // verify that max retries for network and http errors are not reached
+    XCTAssertEqual(stub.stubbedStatusCodes.count, 0);
+}
+
+- (void)testIsNetworkBlockedError {
+    NSError *networkConnectionLostError = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorNetworkConnectionLost userInfo:nil];
+    NSError *cannotFindHostError = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCannotFindHost userInfo:nil];
+    NSError *cannotConnectToHostError = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCannotConnectToHost userInfo:nil];
+    NSError *dnsLookupFailedError = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorDNSLookupFailed userInfo:nil];
+    NSError *nonBlockingError = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorTimedOut userInfo:nil];
+    NSError *otherDomainError = [NSError errorWithDomain:@"OtherDomain" code:123 userInfo:nil];
+    
+    // Network blocking errors should return YES
+    XCTAssertTrue([_uploader isNetworkBlockedError:networkConnectionLostError]);
+    XCTAssertTrue([_uploader isNetworkBlockedError:cannotFindHostError]);
+    XCTAssertTrue([_uploader isNetworkBlockedError:cannotConnectToHostError]);
+    XCTAssertTrue([_uploader isNetworkBlockedError:dnsLookupFailedError]);
+    
+    // Non-blocking errors should return NO
+    XCTAssertFalse([_uploader isNetworkBlockedError:nonBlockingError]);
+    XCTAssertFalse([_uploader isNetworkBlockedError:otherDomainError]);
+}
+
+- (void)testNetworkBlockErrorSkipsRetry {
+    SFHttpStub *stub = [SFHttpStub sharedInstance];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for upload tasks completion"];
+    stub.completionHandler = ^{
+        [expectation fulfill];
+    };
+    
+    [stub.stubbedStatusCodes addObject:@(NSURLErrorNetworkConnectionLost)];
+    
+    NSArray *events = @[[SiftEvent eventWithType:nil path:@"path" fields:nil]];
+    [_uploader upload:events];
+    
+    [self waitForExpectationsWithTimeout:3.0 handler:nil];
+    
+    // Verify that only one blocked request sent
+    XCTAssertEqual(stub.capturedRequests.count, 1);
     XCTAssertEqual(stub.stubbedStatusCodes.count, 0);
 }
 


### PR DESCRIPTION
## Purpose

### Issue

When network limits access to Sift API service, Sift framework generates excessive amount of network traffic.
Such traffic is generated as result retry policy that does not detect blocked requests. This leads to the situation when we have a mix of requests which contains retry requests and requests for newly generated requests

Example of such behaviour:
![Screenshot 2025-04-28 at 13 06 12](https://github.com/user-attachments/assets/2784d1bb-4c15-4bd8-9409-2cbb588f5a4d)

```
Task <19BFED3B-73A0-49E2-941A-85CC1A04FACE>.<32> HTTP load failed, 681/0 bytes (error code: -1005 [4:-4])
Task <19BFED3B-73A0-49E2-941A-85CC1A04FACE>.<32> finished with error [-1005] Error Domain=NSURLErrorDomain Code=-1005 "The network connection was lost." UserInfo={_kCFStreamErrorCodeKey=-4, NSUnderlyingError=0x600000cd1710 {Error Domain=kCFErrorDomainCFNetwork Code=-1005 "(null)" UserInfo={NSErrorPeerAddressKey=<CFData 0x60000212c9b0 [0x7ff84002f250]>{length = 16, capacity = 16, bytes = 0x100223827f0000010000000000000000}, _kCFStreamErrorCodeKey=-4, _kCFStreamErrorDomainKey=4}}, _NSURLErrorFailingURLSessionTaskErrorKey=LocalUploadTask <19BFED3B-73A0-49E2-941A-85CC1A04FACE>.<32>, _NSURLErrorRelatedURLSessionTaskErrorKey=(
    "LocalUploadTask <19BFED3B-73A0-49E2-941A-85CC1A04FACE>.<32>"
), NSLocalizedDescription=The network connection was lost., NSErrorFailingURLStringKey=https://api3.siftscience.com/v3/accounts/YOUR_ACCOUNT_ID/mobile_events, NSErrorFailingURLKey=https://api3.siftscience.com/v3/accounts/YOUR_ACCOUNT_ID/mobile_events, _kCFStreamErrorDomainKey=4}
Task <BE7D37EB-7BB2-45EE-935E-EC534107251F>.<33> HTTP load failed, 681/0 bytes (error code: -1005 [4:-4])
Task <BE7D37EB-7BB2-45EE-935E-EC534107251F>.<33> finished with error [-1005] Error Domain=NSURLErrorDomain Code=-1005 "The network connection was lost." UserInfo={_kCFStreamErrorCodeKey=-4, NSUnderlyingError=0x600000ceb150 {Error Domain=kCFErrorDomainCFNetwork Code=-1005 "(null)" UserInfo={NSErrorPeerAddressKey=<CFData 0x600002140190 [0x7ff84002f250]>{length = 16, capacity = 16, bytes = 0x100223827f0000010000000000000000}, _kCFStreamErrorCodeKey=-4, _kCFStreamErrorDomainKey=4}}, _NSURLErrorFailingURLSessionTaskErrorKey=LocalUploadTask <BE7D37EB-7BB2-45EE-935E-EC534107251F>.<33>, _NSURLErrorRelatedURLSessionTaskErrorKey=(
    "LocalUploadTask <BE7D37EB-7BB2-45EE-935E-EC534107251F>.<33>"
), NSLocalizedDescription=The network connection was lost., NSErrorFailingURLStringKey=https://api3.siftscience.com/v3/accounts/YOUR_ACCOUNT_ID/mobile_events, NSErrorFailingURLKey=https://api3.siftscience.com/v3/accounts/YOUR_ACCOUNT_ID/mobile_events, _kCFStreamErrorDomainKey=4}
Task <08F277C9-9896-4E28-83B6-3C5910586EF1>.<34> HTTP load failed, 681/0 bytes (error code: -1005 [4:-4])
Task <08F277C9-9896-4E28-83B6-3C5910586EF1>.<34> finished with error [-1005] Error Domain=NSURLErrorDomain Code=-1005 "The network connection was lost." UserInfo={_kCFStreamErrorCodeKey=-4, NSUnderlyingError=0x600000cc1da0 {Error Domain=kCFErrorDomainCFNetwork Code=-1005 "(null)" UserInfo={NSErrorPeerAddressKey=<CFData 0x60000213be80 [0x7ff84002f250]>{length = 16, capacity = 16, bytes = 0x100223827f0000010000000000000000}, _kCFStreamErrorCodeKey=-4, _kCFStreamErrorDomainKey=4}}, _NSURLErrorFailingURLSessionTaskErrorKey=LocalUploadTask <08F277C9-9896-4E28-83B6-3C5910586EF1>.<34>, _NSURLErrorRelatedURLSessionTaskErrorKey=(
    "LocalUploadTask <08F277C9-9896-4E28-83B6-3C5910586EF1>.<34>"
), NSLocalizedDescription=The network connection was lost., NSErrorFailingURLStringKey=https://api3.siftscience.com/v3/accounts/YOUR_ACCOUNT_ID/mobile_events, NSErrorFailingURLKey=https://api3.siftscience.com/v3/accounts/YOUR_ACCOUNT_ID/mobile_events, _kCFStreamErrorDomainKey=4}
Task <BB08EE69-4260-4040-BE0B-DCE52640A52D>.<35> HTTP load failed, 681/0 bytes (error code: -1005 [4:-4])
Task <BB08EE69-4260-4040-BE0B-DCE52640A52D>.<35> finished with error [-1005] Error Domain=NSURLErrorDomain Code=-1005 "The network connection was lost." UserInfo={_kCFStreamErrorCodeKey=-4, NSUnderlyingError=0x600000cc32a0 {Error Domain=kCFErrorDomainCFNetwork Code=-1005 "(null)" UserInfo={NSErrorPeerAddressKey=<CFData 0x60000215df90 [0x7ff84002f250]>{length = 16, capacity = 16, bytes = 0x100223827f0000010000000000000000}, _kCFStreamErrorCodeKey=-4, _kCFStreamErrorDomainKey=4}}, _NSURLErrorFailingURLSessionTaskErrorKey=LocalUploadTask <BB08EE69-4260-4040-BE0B-DCE52640A52D>.<35>, _NSURLErrorRelatedURLSessionTaskErrorKey=(
    "LocalUploadTask <BB08EE69-4260-4040-BE0B-DCE52640A52D>.<35>"
), NSLocalizedDescription=The network connection was lost., NSErrorFailingURLStringKey=https://api3.siftscience.com/v3/accounts/YOUR_ACCOUNT_ID/mobile_events, NSErrorFailingURLKey=https://api3.siftscience.com/v3/accounts/YOUR_ACCOUNT_ID/mobile_events, _kCFStreamErrorDomainKey=4}
``` 

### Solution

Based on observation there is a specific set of error that could indicate that network requests are blocked and drop retries when they are detected.

## Summary

- Uploader drop a batch when  requests is blocked by firewall.
- Adds logic for detecting errors blocked by firewall
- Updates `SFStubHttpProtocol` to simulate different network errors for requests

## Testing

Block access to API endpoint.
SiftUploader should send only one request per batch when network is blocked

## Checklist
- [x] The change was thoroughly tested manually
- [x] The change was covered with unit tests
- [x] The change was tested with the integration example
- [x] Necessary changes were made in the integration example (if applicable)
- [x] New functionality is reflected in README (if applicable)
